### PR TITLE
fix: add S3 region configuration to DuckDB httpfs extension

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -281,7 +281,8 @@ class Component(ComponentBase):
                                                     normalized_columns,
                                                     s3_path,
                                                     aws_params[KEY_AWS_API_KEY_ID],
-                                                    aws_params[KEY_AWS_API_KEY_SECRET])
+                                                    aws_params[KEY_AWS_API_KEY_SECRET],
+                                                    aws_params[KEY_AWS_REGION])
 
     def _read_s3_file_contents(self, key):
         try:

--- a/src/duckdb_client.py
+++ b/src/duckdb_client.py
@@ -92,7 +92,8 @@ class DuckDBClient:
 
     def load_csv_from_s3(self, table_name: str, original_columns: list[str],
                          normalized_columns: list[str], s3_path: str,
-                         aws_access_key_id: str, aws_secret_access_key: str):
+                         aws_access_key_id: str, aws_secret_access_key: str,
+                         aws_region: str):
         """
         Load CSV directly from S3 using DuckDB's httpfs extension.
 
@@ -103,6 +104,7 @@ class DuckDBClient:
             s3_path: S3 path (s3://bucket/key)
             aws_access_key_id: AWS access key
             aws_secret_access_key: AWS secret key
+            aws_region: AWS region (e.g., "us-east-1", "eu-central-1")
         """
         logging.debug(f"Loading from S3: {s3_path}")
 
@@ -110,9 +112,10 @@ class DuckDBClient:
         self._connection.execute("INSTALL httpfs")
         self._connection.execute("LOAD httpfs")
 
-        # Set S3 credentials
+        # Set S3 credentials and region
         self._connection.execute(f"SET s3_access_key_id='{aws_access_key_id}'")
         self._connection.execute(f"SET s3_secret_access_key='{aws_secret_access_key}'")
+        self._connection.execute(f"SET s3_region='{aws_region}'")
 
         # Build SELECT with original names and aliases to normalized names
         select_parts = []


### PR DESCRIPTION
## Summary
Fixes missing S3 region configuration in DuckDB httpfs extension, which causes HTTP 400 errors when accessing S3 buckets that require a specific region.

## Problem
The `DuckDBClient.load_csv_from_s3()` method was setting only `s3_access_key_id` and `s3_secret_access_key` for DuckDB's httpfs extension, but not `s3_region`. This causes errors when DuckDB tries to access S3 buckets that enforce region-specific endpoints.

## Solution
- Added `aws_region` parameter to `DuckDBClient.load_csv_from_s3()` method signature
- Added `SET s3_region='{aws_region}'` DuckDB command alongside existing credential settings
- Updated the call in `component.py` to pass `aws_params[KEY_AWS_REGION]`

## Details
The `aws_region` value was already available in the component configuration (`aws_parameters.aws_region`) and was being used for the boto3 S3 client initialization. This PR ensures DuckDB also uses the same region configuration.

## Testing
- [ ] Test with S3 bucket in eu-central-1
- [ ] Test with S3 bucket in us-east-1
- [ ] Verify no HTTP 400 errors during CSV loading from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)