### PR TITLE
[L1-114] Update component short description

### DIFF
--- a/component_config/component_short_description.md
+++ b/component_config/component_short_description.md
@@ -1,2 +1,1 @@
-The AWS Cost & Usage Report contains the most comprehensive set of AWS cost and usage data available, 
-including additional metadata about AWS services, pricing, Reserved Instances, and Savings Plans.
+Extracts AWS Cost & Usage Reports from S3.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `kds-team.ex-aws-cost-and-usage-reports` -> Extracts AWS Cost & Usage Reports from S3.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.